### PR TITLE
added the option of choosing a PYTHON36 when creating the code envior…

### DIFF
--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27"],
+  "acceptedPythonInterpreters": ["PYTHON27","PYTHON36"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false


### PR DESCRIPTION
I have added the option to create a code environment with python36 since it is necessary for some of the plugin packages. 