### PR TITLE
Bump python compatibility to 3.10 + Fix word2vec download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## [Version 2.0.0](https://github.com/dataiku/dss-plugin-nlp-embedding/releases/tag/v1.0.0) - Python 3 - 2022-09
+## [Version 2.1.0](https://github.com/dataiku/dss-plugin-nlp-embedding/releases/tag/v2.1.0) - 2023-04
+
+- ✨ Python 3.8 to 3.10 support & fix Word2vec
+
+## [Version 2.0.0](https://github.com/dataiku/dss-plugin-nlp-embedding/releases/tag/v2.0.0) - Python 3 - 2022-09
 
 - ✨ Python 3 support & various bugfixes

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Dataiku
+   Copyright 2023 Dataiku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310"],
   "forceConda": false,
   "installCorePackages": true,
-  "installJupyterSupport": false
+  "installJupyterSupport": false,
+  "corePackagesSet": "AUTO"
 }

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,7 @@
-gensim>=3.8,<=4.3.1
+gensim==3.8.1; python_version == '2.7'
+gensim==4.1.2; python_version == '3.6'
+gensim==4.2.0; python_version == '3.7'
+gensim==4.3.1; python_version >= '3.8'
 scikit-learn>=0.20,<=1.0.2
 tensorflow>=2.1,<=2.11.1
 tensorflow-hub==0.9.0

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,4 +1,4 @@
-gensim==3.8.1; python_version == '2.7'
+gensim==3.8.2; python_version == '2.7'
 gensim==4.1.2; python_version == '3.6'
 gensim==4.2.0; python_version == '3.7'
 gensim==4.3.1; python_version >= '3.8'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -4,6 +4,6 @@ gensim==4.2.0; python_version == '3.7'
 gensim==4.3.1; python_version >= '3.8'
 scikit-learn>=0.20,<=1.0.2
 tensorflow>=2.1,<=2.11.1
-tensorflow-hub==0.9.0
+tensorflow-hub==0.7.0
 grpcio==1.39.0; python_version <= '3.6'
 grpcio==1.54.0; python_version >= '3.7'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -5,3 +5,4 @@ gensim==4.3.1; python_version >= '3.8'
 scikit-learn>=0.20,<=1.0.2
 tensorflow>=2.1,<=2.11.1
 tensorflow-hub==0.9.0
+grpcio==1.39.0; python_version <= '3.6'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,8 +1,4 @@
-numpy==1.16.4
-scipy==1.2.2
-gensim==3.8.2
-scikit-learn==0.20.4
-grpcio==1.36.1; python_version <= '3.6'
-tensorflow==1.15.*
-tensorflow-hub==0.5.0
-protobuf==3.20.*; python_version == '3.7'
+gensim>=3.8,<=4.3.1
+scikit-learn>=0.20,<=1.0.2
+tensorflow>=2.1,<=2.11.1
+tensorflow-hub==0.9.0

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn>=0.20,<=1.0.2
 tensorflow>=2.1,<=2.11.1
 tensorflow-hub==0.9.0
 grpcio==1.39.0; python_version <= '3.6'
+grpcio==1.54.0; python_version >= '3.7'

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "sentence-embedding",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "meta": {
         "label": "Text Embedding",
         "category": "Natural Language Processing",

--- a/python-lib/dku_language_model/context_independent_language_model.py
+++ b/python-lib/dku_language_model/context_independent_language_model.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 from collections import Counter
+from distutils.version import LooseVersion
+import gensim
 from gensim.models import KeyedVectors
 from sklearn.decomposition import TruncatedSVD
 from dku_language_model.abstract_language_model import AbstractLanguageModel
@@ -104,7 +106,10 @@ class Word2vecModel(ContextIndependentLanguageModel):
         logger.info('Loading Word2Vec model...')
         model = KeyedVectors.load_word2vec_format(self.model_path, binary=True)
         logger.info('Done')
-        self.word2idx = {w: i for i, w in enumerate(model.index2word)}
+        if LooseVersion(gensim.__version__) < LooseVersion("4.0.0"):
+            self.word2idx = {w: i for i, w in enumerate(model.index2word)}
+        else:
+            self.word2idx = {w: i for i, w in enumerate(model.index_to_key)}
         self.embedding_matrix = model.vectors
 
 

--- a/python-lib/dku_language_model/contextual_language_model.py
+++ b/python-lib/dku_language_model/contextual_language_model.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import tensorflow_hub as hub
 from dku_language_model.abstract_language_model import AbstractLanguageModel
 from dku_language_model.language_model_utils import clean_text
 import logging
+
 logger = logging.getLogger(__name__)
+
+tf.disable_v2_behavior()
 
 
 class ContextualLanguageModel(AbstractLanguageModel):


### PR DESCRIPTION
Also fixes `Word2vec` download

[sc-132148]

Note to the reviewers: please test that the download macro for the 4 embeddings and plugin recipes work for the following python versions: 2.7, 3.6, 3.7, 3.8, 3.9, 3.10